### PR TITLE
Log more in 'Received error message without cmdId' to aid debugging

### DIFF
--- a/aiosonos/api/websockets.py
+++ b/aiosonos/api/websockets.py
@@ -188,7 +188,7 @@ class SonosLocalWebSocketsApi(AbstractSonosApi):
         # handle error message
         if "errorCode" in msg_data:
             if "cmdId" not in msg:
-                self.logger.error("Received error message without cmdId: %s, msg_data=%s", msg, msg_data)
+                self.logger.error("Received unhandled error: %s: %s", msg, msg_data)
                 return
             if future := self._result_futures.get(msg["cmdId"]):
                 future.set_exception(

--- a/aiosonos/api/websockets.py
+++ b/aiosonos/api/websockets.py
@@ -188,7 +188,7 @@ class SonosLocalWebSocketsApi(AbstractSonosApi):
         # handle error message
         if "errorCode" in msg_data:
             if "cmdId" not in msg:
-                self.logger.error("Received error message without cmdId: %s", msg)
+                self.logger.error("Received error message without cmdId: %s, msg_data=%s", msg, msg_data)
                 return
             if future := self._result_futures.get(msg["cmdId"]):
                 future.set_exception(


### PR DESCRIPTION
Somehow my Sonos Move speaker would not play songs from Spotify when controlled from music-assistant.
(Mass 2.3.1, HA 2024.10.4, Sonos Move version 81.1-58074)

I was trying to find the problem and ran into this, by logging this at least I could get an errorCode from sonos.
It might be helpful to somebody else.

The playback problem here will remain a mystery because minutes after changing this file it started working again (after 24 hours of not working).