### PR TITLE
Fix event_filter type to accept multiple EventTypes

### DIFF
--- a/aiosonos/client.py
+++ b/aiosonos/client.py
@@ -81,7 +81,7 @@ class SonosLocalApiClient:
     def subscribe(
         self,
         cb_func: EventCallBackType,
-        event_filter: EventType | tuple[EventType] | None = None,
+        event_filter: EventType | tuple[EventType, ...] | None = None,
         object_id_filter: str | tuple[str] | None = None,
     ) -> Callable[[], None]:
         """Add callback to event listeners.


### PR DESCRIPTION
Change `event_filter` parameter type from `tuple[EventType]` to `tuple[EventType, ...]`

The single-element tuple type was incorrect as the method accepts multiple event types