### PR TITLE
Add optional fields 'id' and 'imageUrl' to models

### DIFF
--- a/aiosonos/api/models.py
+++ b/aiosonos/api/models.py
@@ -333,6 +333,8 @@ class Service(TypedDict):
 
     _objectType: str  # = service
     name: str
+    id: NotRequired[str]
+    imageUrl: NotRequired[str]
     images: NotRequired[list[Image]]
 
 
@@ -504,6 +506,7 @@ class Container(TypedDict):
     _objectType: str  # = container
     name: str
     type: str
+    imageUrl: NotRequired[str]
     id: NotRequired[MetadataId]
     service: NotRequired[Service]
     images: NotRequired[list[Image]]


### PR DESCRIPTION
Adds three optional fields to the Container and Service TypedDicts to match the Sonos API specification for the loadStreamUrl endpoint. 

### Changes
**Container TypedDict:**

Added imageUrl: NotRequired[str]

**Service TypedDict:**

Added id: NotRequired[str]
Added imageUrl: NotRequired[str]

### Rationale
These fields are documented in the Sonos API's playbackSession.loadStreamUrl endpoint ([API Reference](https://docs.sonos.com/reference/playbacksession-loadstreamurl-sessionid)):

- STATIONMETADATA object (maps to Container): accepts imageUrl field
- SERVICE object: accepts both id and imageUrl fields

Note: While imageUrl is marked as deprecated in the API docs (replaced by images array), it is still accepted and functional. The current TypedDict definitions are stricter than the actual API, requiring applications to use type casts when constructing these objects.