### PR TITLE
Pin GitHub Actions to full SHAs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Summary
+
+## Checklist
+
+- [ ] No mutable GitHub Actions refs remain
+- [ ] YAML validates
+- [ ] Commit includes the `Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>` trailer
+- [ ] CI is green
+- [ ] Copilot comments are resolved

--- a/.github/workflows/auto_approve_dependabot.yml
+++ b/.github/workflows/auto_approve_dependabot.yml
@@ -9,4 +9,4 @@ jobs:
       pull-requests: write
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: hmarr/auto-approve-action@v4
+      - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🏷 Verify PR has a valid label
-        uses: ludeeus/action-require-labels@1.1.0
+        uses: ludeeus/action-require-labels@7ef0dba93830452589680da7cdea2e2c4c0f8dff # v1.1.0
         with:
           labels: >-
             breaking-change, bugfix, refactor, new-feature, maintenance, ci, dependencies

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -11,12 +11,12 @@ jobs:
     outputs:
       version: ${{ steps.vars.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Get tag
         id: vars
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5.3.0
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: "3.10"
       - name: Install build
@@ -39,7 +39,7 @@ jobs:
         run: >-
           python3 -m build
       - name: Publish release to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.12.4
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v6.1.0
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,15 +10,29 @@ on:
     branches: [main]
 
 jobs:
+  actions-audit:
+    name: Audit GitHub Actions refs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - name: Set up Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: "3.11"
+      - name: Audit action pins
+        run: python scripts/check_action_pins.py
+
   lint:
     runs-on: ubuntu-latest
     continue-on-error: true
 
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Set up Python
-        uses: actions/setup-python@v5.3.0
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: "3.11"
       - name: Install dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,16 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-yaml
   - repo: local
     hooks:
+      - id: action-pins
+        name: 🔒 Check GitHub Actions refs are immutable
+        language: system
+        entry: scripts/run-in-env.sh python3 scripts/check_action_pins.py
+        pass_filenames: false
+        stages: [pre-commit, pre-push, manual]
       - id: ruff-check
         name: 🐶 Ruff Linter
         language: system

--- a/scripts/check_action_pins.py
+++ b/scripts/check_action_pins.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Validate that GitHub Actions refs are immutable."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+USES_PATTERN = re.compile(r"^\s*uses:\s*(?P<value>\S+)")
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+WORKFLOW_DIRS = (Path(".github/workflows"), Path(".github/actions"))
+
+
+def iter_yaml_files() -> list[Path]:
+    """Return all workflow and composite-action YAML files."""
+    files: list[Path] = []
+    for base in WORKFLOW_DIRS:
+        if not base.exists():
+            continue
+        files.extend(sorted(base.rglob("*.yml")))
+        files.extend(sorted(base.rglob("*.yaml")))
+    return files
+
+
+def is_local_ref(value: str) -> bool:
+    """Return True for local or container-based action refs."""
+    return value.startswith(("./", "../", "docker://"))
+
+
+def main() -> int:
+    """Exit non-zero when any mutable action refs remain."""
+    violations: list[str] = []
+    for path in iter_yaml_files():
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            match = USES_PATTERN.match(line)
+            if not match:
+                continue
+
+            value = match.group("value").split("#", 1)[0].strip()
+            if is_local_ref(value):
+                continue
+
+            if "@" not in value:
+                violations.append(f"{path}:{lineno}: missing immutable ref: {value}")
+                continue
+
+            ref = value.rsplit("@", 1)[1]
+            if not SHA_PATTERN.fullmatch(ref):
+                violations.append(f"{path}:{lineno}: mutable ref: {value}")
+
+    if violations:
+        sys.stdout.write("Mutable GitHub Actions refs found:\n")
+        for violation in violations:
+            sys.stdout.write(f"  - {violation}\n")
+        return 1
+
+    sys.stdout.write("No mutable GitHub Actions refs found.\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Pin every external GitHub Actions ref to a full SHA with an exact version comment.
- Add an action-pin audit and YAML validation to CI/local pre-commit.
- Add a concise PR template covering immutable refs, YAML, CI, and Copilot resolution.

## Validation
- `python scripts/check_action_pins.py`
- `pre-commit run check-yaml --all-files`

Supersedes PRs #157, #156, #155, #149, and #134; left open.
